### PR TITLE
Allow using a project-level catalog file as well

### DIFF
--- a/XML.novaextension/README.md
+++ b/XML.novaextension/README.md
@@ -65,6 +65,18 @@ You can opt into it like this:
 </syntax>
 ```
 
+**Local Catalog**
+
+If your project uses its own `catalog.xml` file for mapping namespaces to schemas, you can point to its folder using a configuration setting, e.g.:
+
+```json
+{
+  "xml.catalogFolder": "src/xml"
+}
+```
+
+This will let XML Extension load mappings from `src/xml/catalog.xml` as well.
+
 ### Writing Schemas
 
 W3 Schools has good tutorials for creating both [DTD](https://www.w3schools.com/xml/xml_dtd_intro.asp)

--- a/XML.novaextension/README.md
+++ b/XML.novaextension/README.md
@@ -67,15 +67,9 @@ You can opt into it like this:
 
 **Local Catalog**
 
-If your project uses its own `catalog.xml` file for mapping namespaces to schemas, you can point to its folder using a configuration setting, e.g.:
+If your project uses its own catalog file(s) for mapping namespaces to schemas, you can point to them in the project's configuration settings for **XML**.
 
-```json
-{
-  "xml.catalogFolder": "src/xml"
-}
-```
-
-This will let XML Extension load mappings from `src/xml/catalog.xml` as well.
+This will allow XML Extension to load mappings from your local files as well.
 
 ### Writing Schemas
 

--- a/XML.novaextension/extension.json
+++ b/XML.novaextension/extension.json
@@ -27,6 +27,15 @@
     }
   ],
 
+  "configWorkspace": [
+    {
+      "title": "XML Catalog file(s)",
+      "description": "A catalog file allows you to associate a namespace with a Schema file for validation.",
+      "key": "robb-j.xml.catalogFiles",
+      "type": "pathArray"
+    }
+  ],
+
   "commands": {
     "editor": [
       {

--- a/src/Scripts/xml-language-server.ts
+++ b/src/Scripts/xml-language-server.ts
@@ -35,6 +35,18 @@ export class XmlLanguageServer {
         : nova.extension.globalStoragePath
 
       const catalogPath = nova.path.join(packageDir, 'Schemas/catalog.xml')
+      let catalogList = [catalogPath]
+
+      const projectPath = nova.workspace.path
+      const localCatalogFolder = nova.workspace.config.get(
+        'xml.catalogFolder',
+        'string'
+      )
+      if (localCatalogFolder !== null && projectPath !== null) {
+        catalogList.push(
+          nova.path.join(projectPath, localCatalogFolder, 'catalog.xml')
+        )
+      }
 
       const serverOptions = await this.getServerOptions(
         packageDir,
@@ -45,7 +57,7 @@ export class XmlLanguageServer {
         initializationOptions: {
           settings: {
             xml: {
-              catalogs: [catalogPath],
+              catalogs: catalogList,
             },
           },
         },

--- a/src/Scripts/xml-language-server.ts
+++ b/src/Scripts/xml-language-server.ts
@@ -37,15 +37,13 @@ export class XmlLanguageServer {
       const catalogPath = nova.path.join(packageDir, 'Schemas/catalog.xml')
       let catalogList = [catalogPath]
 
-      const projectPath = nova.workspace.path
-      const localCatalogFolder = nova.workspace.config.get(
-        'xml.catalogFolder',
-        'string'
+      let localCatalogs = nova.workspace.config.get(
+        'robb-j.xml.catalogFiles',
+        'array'
       )
-      if (localCatalogFolder !== null && projectPath !== null) {
-        catalogList.push(
-          nova.path.join(projectPath, localCatalogFolder, 'catalog.xml')
-        )
+
+      if (localCatalogs !== null && localCatalogs.length > 0) {
+        catalogList = catalogList.concat(localCatalogs)
       }
 
       const serverOptions = await this.getServerOptions(


### PR DESCRIPTION
This is a draft PR, just in case - curious to hear if you'd consider adding this feature.

This looks in the project's configuration for a setting called `xml.catalogFolder` and if found, will try to load a `catalog.xml` file from that location and add it to the initialization options' `catalogs` array.

I'm not sure if the filename should be configurable as well - maybe it's simpler to name the setting `xml.catalogFile` instead, and expect the full path?

Cheers,
Chriztian
